### PR TITLE
Parse commit objects

### DIFF
--- a/include/blob.h
+++ b/include/blob.h
@@ -10,7 +10,7 @@ class GitBlob : public GitObject {
 public:
   GitBlob(const std::string &data = std::string(""));
 
-  void deserialise(std::string &data) override;
+  void deserialise(const std::string &data) override;
   std::string serialise(GitRepository &repo) override;
 
   void init();

--- a/include/commit.h
+++ b/include/commit.h
@@ -1,0 +1,24 @@
+#ifndef COMMIT_H
+#define COMMIT_H
+
+#include <string>
+#include <unordered_map>
+
+#include "object.h"
+
+class GitCommit : public GitObject {
+public:
+  GitCommit(const std::string &data = std::string(""));
+
+  void deserialise(
+      const std::string &data) override; // convert string format to data object
+  std::string
+  serialise(GitRepository &repo) override; // convert this to a string format
+  std::string print_commit(GitRepository &repo);
+  void init();
+
+protected:
+  std::unordered_map<std::string, std::string> keyValuePairs;
+};
+
+#endif // COMMIT_H

--- a/include/object.h
+++ b/include/object.h
@@ -12,7 +12,7 @@ public:
   GitObject();
   GitObject(const std::string &data);
 
-  virtual void deserialise(std::string &data) = 0;
+  virtual void deserialise(const std::string &data) = 0;
   virtual std::string serialise(GitRepository &repo) = 0;
 
   static std::string write(GitRepository &repo, std::string &type,

--- a/run.sh
+++ b/run.sh
@@ -27,8 +27,3 @@ make
 # symlink - so I can run it like gyt [arguments....]
 sudo rm /usr/local/bin/gyt
 sudo ln -s "$(pwd)/app/adder_app" /usr/local/bin/gyt
-
-
-# Change to the "app" directory and run the application
-# cd app
-# ./adder_app init

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(repository PRIVATE inih util boost_libraries)
 target_include_directories(repository PUBLIC ../include)
 target_compile_features(repository PUBLIC cxx_std_17)
 
-add_library(object object.cpp blob.cpp)
+add_library(object object.cpp blob.cpp commit.cpp)
 target_link_libraries(object PRIVATE repository boost_libraries)
 target_include_directories(object PUBLIC ../include)
 target_compile_features(object PUBLIC cxx_std_17)

--- a/src/blob.cpp
+++ b/src/blob.cpp
@@ -14,4 +14,4 @@ GitBlob::GitBlob(const std::string &blobData)
 
 std::string GitBlob::serialise(GitRepository &repo) { return blobData; }
 
-void GitBlob::deserialise(std::string &data) { this->blobData = data; }
+void GitBlob::deserialise(const std::string &data) { this->blobData = data; }

--- a/src/commit.cpp
+++ b/src/commit.cpp
@@ -1,0 +1,63 @@
+#include "commit.h"
+#include "repository.h"
+#include <sstream>
+GitCommit::GitCommit(const std::string &data) : GitObject() {
+  this->deserialise(data);
+};
+
+std::string GitCommit::serialise(GitRepository &repo) {
+  std::stringstream ss;
+  ss << "tree " << this->keyValuePairs["tree"] << "\n";
+  ss << "parent " << this->keyValuePairs["parent"] << "\n";
+  ss << "author " << this->keyValuePairs["author_name"] << " <"
+     << this->keyValuePairs["author_email"] << "> "
+     << this->keyValuePairs["author_unix_timestamp"] << " "
+     << this->keyValuePairs["author_timezone"] << "\n";
+  ss << "committer " << this->keyValuePairs["committer_name"] << " "
+     << this->keyValuePairs["committer_email"] << "> "
+     << this->keyValuePairs["committer_unix_timestamp"] << " "
+     << this->keyValuePairs["committer_timezone"] << "\n";
+  ss << this->keyValuePairs["message"];
+  return ss.str();
+}
+
+std::string GitCommit::print_commit(GitRepository &repo) {
+  std::stringstream ss;
+  ss << "commit " << this->keyValuePairs["commit"] << "\n";
+  ss << "Author: " << this->keyValuePairs["author"] << "\n";
+  ss << "Date: " << this->keyValuePairs["date"] << "\n";
+  ss << this->keyValuePairs["message"] << "\n";
+  return ss.str();
+}
+
+void GitCommit::deserialise(const std::string &data) {
+  const std::unordered_map<std::string, std::string> keyValuePairs;
+  int pos = 0;
+
+  const std::array<std::string, 4> keys = {"tree", "parent", "author",
+                                           "committer"};
+  const std::vector<std::pair<std::string, std::string>> sub_keys = {
+      {"name", " <"},
+      {"email", "> "},
+      {"unix_timestamp", " "},
+      {"timezone", "\n"}};
+  for (auto &key : keys) {
+    int space = data.find(key + " ", pos);
+    int nl = data.find("\n", space);
+    if (key == "author" || key == "committer") {
+      pos = space + key.size() + 1;
+      for (auto &sub_key : sub_keys) {
+        space = data.find(sub_key.second, pos);
+        this->keyValuePairs[key + "_" + sub_key.first] =
+            data.substr(pos, space - pos);
+        pos = space + sub_key.second.size();
+      }
+    } else {
+      this->keyValuePairs[key] =
+          data.substr(space + key.size() + 1, nl - space - key.size() - 1);
+    }
+    pos = nl + 1;
+  }
+  int nl = data.find("\n", pos + 1);
+  this->keyValuePairs["message"] = data.substr(pos, nl - pos);
+}

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -58,6 +58,8 @@ GitObject *GitObject::read(GitRepository &repo, const std::string &sha) {
     std::cout << "Object type: " << fmt << std::endl;
     std::cout << "Object size: " << size << std::endl;
     return new GitBlob(raw.substr(y + 1));
+  } else if (fmt == "commit") {
+    return new GitCommit(raw.substr(y + 1));
   } else {
     throw std::runtime_error("Unknown type");
   }


### PR DESCRIPTION
1. Supports the command `cat-file commit <commit hash>`
2. Minor update to use const lvalue references as an argument